### PR TITLE
fix inconsistent usages

### DIFF
--- a/hid_parser/__init__.py
+++ b/hid_parser/__init__.py
@@ -768,11 +768,11 @@ class ReportDescriptor():
         else:
             if len(usages) != report_count:
                 error_str = f'Expecting {report_count} usages but got {len(usages)}'
-                if len(usages) == 1:
-                    warnings.warn(HIDComplianceWarning(error_str))
-                    usages *= report_count
+                warnings.warn(HIDComplianceWarning(error_str))
+                if len(usages) > report_count:
+                    report_count = len(usages)
                 else:
-                    raise InvalidReportDescriptor(error_str)
+                    usages += [] * report_count - len(usages)
 
             for usage in usages:
                 item = VariableItem(


### PR DESCRIPTION
My Razer Huntsman Mini keyboard has some inconsistent usages/report_count which make the parser fail.

This PR adds empty usages to make it consistent.