### PR TITLE
ci: fix workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,14 +14,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install mypy
       run: |
@@ -33,19 +35,19 @@ jobs:
       run: pip install typing-extensions
 
     - name: Run mypy
-      run: mypy --python-version ${{ matrix.python }} -p hid_parser
+      run: mypy --python-version ${{ matrix.python-version }} -p hid_parser
 
 
   pre-commit:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Run pre-commit
-      uses: pre-commit/action@v2.0.0
+      uses: pre-commit/action@v3.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,19 +14,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up target Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: Install nox
         run: |
@@ -34,12 +36,12 @@ jobs:
             nox --version
 
       - name: Run tests
-        run: nox -s test-${{ matrix.python }}
+        run: nox -s test-${{ matrix.python-version }}
 
       - name: Send coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         env:
-          PYTHON: ${{ matrix.python }}
+          PYTHON: ${{ matrix.python-version }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: PYTHON

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,14 @@ repos:
   - id: double-quote-string-fixer
   - id: end-of-file-fixer
   - id: trailing-whitespace
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: master
+- repo: https://github.com/PyCQA/isort
+  rev: 5.12.0
   hooks:
   - id: isort
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.3
+    language_version: python3.9
+- repo: https://github.com/PyCQA/flake8
+  rev: 6.1.0
   hooks:
   - id: flake8
     additional_dependencies: ['flake8-per-file-ignores']
-    language_version: python3.7
+    language_version: python3.9

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def mypy(session):
     session.run('mypy', '-p', 'hid_parser')
 
 
-@nox.session(python=['3.7', '3.8', '3.9'])
+@nox.session(python=['3.8', '3.9', '3.10'])
 def test(session):
     htmlcov_output = os.path.join(session.virtualenv.location, 'htmlcov')
     xmlcov_output = os.path.join(session.virtualenv.location, f'coverage-{session.python}.xml')


### PR DESCRIPTION
The CI had a large number of errors and warnings when I tried to run it on my fork. Many problems were due to out-of-date hook versions or deprecated Python versions.